### PR TITLE
Add @Incidence add method to support add* methods in Frames

### DIFF
--- a/src/test/java/com/syncleus/ferma/ExtendedFramedEdgeTest.java
+++ b/src/test/java/com/syncleus/ferma/ExtendedFramedEdgeTest.java
@@ -18,66 +18,79 @@
  ******************************************************************************/
 package com.syncleus.ferma;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
+
 import com.tinkerpop.blueprints.Graph;
-import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
+import com.tinkerpop.blueprints.impls.tg.TinkerGraphFactory;
 
-public class FramedEdgeTest {
+public class ExtendedFramedEdgeTest {
 
-    private Person p1;
-    private Person p2;
+	private static final Set<Class<?>> TEST_TYPES = new HashSet<Class<?>>(
+    		Arrays.asList(new Class<?>[]{
+    				Person.class, 
+    				Friend.class,
+    				Knows.class
+    				}
+    		));
+	private Friend p1;
+    private Friend p2;
     private Knows e1;
 
     @Before
     public void init() {
+    	
         MockitoAnnotations.initMocks(this);
-        final Graph g = new TinkerGraph();
-        final FramedGraph fg = new DelegatingFramedGraph(g);
-        p1 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
-        p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        final Graph g =TinkerGraphFactory.createTinkerGraph();
+        final FramedGraph fg = new DelegatingFramedGraph(g, TEST_TYPES);
+        p1 = fg.addFramedVertex(Friend.class);
+        p2 = fg.addFramedVertex(Friend.class);
         p1.setName("Bryn");
         p2.setName("Julia");
-        e1 = p1.addKnows(p2);
+        e1 = p1.addKnowsIncidence(p2);
         e1.setYears(15);
         
     }
 
     @Test
     public void testLabel() {
-        Assert.assertEquals("knows", e1.getLabel());
+        Assert.assertEquals(Knows.class.getCanonicalName(), e1.getLabel());
     }
 
     @Test
     public void testInV() {
-        Assert.assertEquals(p2, e1.inV().next(Person.class));
+        Assert.assertEquals(p2, e1.inV().next(Friend.class));
     }
 
     @Test
     public void testOutV() {
-        Assert.assertEquals(p1, e1.outV().next(Person.class));
+        Assert.assertEquals(p1, e1.outV().next(Friend.class));
     }
 
     @Test
     public void testBothV() {
-        Assert.assertEquals(p1, e1.bothV().next(Person.class));
+        Assert.assertEquals(p1, e1.bothV().next(Friend.class));
     }
 
     @Test
     public void testInVExplicit() {
-        Assert.assertEquals(p2, e1.inV().nextExplicit(Person.class));
+        Assert.assertEquals(p2, e1.inV().nextExplicit(Friend.class));
     }
 
     @Test
     public void testOutVExplicit() {
-        Assert.assertEquals(p1, e1.outV().nextExplicit(Person.class));
+        Assert.assertEquals(p1, e1.outV().nextExplicit(Friend.class));
     }
 
     @Test
     public void testBothVExplicit() {
-        Assert.assertEquals(p1, e1.bothV().nextExplicit(Person.class));
+        Assert.assertEquals(p1, e1.bothV().nextExplicit(Friend.class));
     }
     
 }

--- a/src/test/java/com/syncleus/ferma/Friend.java
+++ b/src/test/java/com/syncleus/ferma/Friend.java
@@ -1,0 +1,30 @@
+/******************************************************************************
+ *                                                                             *
+ *  Copyright: (c) Syncleus, Inc.                                              *
+ *                                                                             *
+ *  You may redistribute and modify this source code under the terms and       *
+ *  conditions of the Open Source Community License - Type C version 1.0       *
+ *  or any later version as published by Syncleus, Inc. at www.syncleus.com.   *
+ *  There should be a copy of the license included with this file. If a copy   *
+ *  of the license is not included you are granted no right to distribute or   *
+ *  otherwise use this file except through a legal and valid license. You      *
+ *  should also contact Syncleus, Inc. at the information below if you cannot  *
+ *  find a license:                                                            *
+ *                                                                             *
+ *  Syncleus, Inc.                                                             *
+ *  2604 South 12th Street                                                     *
+ *  Philadelphia, PA 19148                                                     *
+ *                                                                             *
+ ******************************************************************************/
+package com.syncleus.ferma;
+
+import com.syncleus.ferma.annotations.Incidence;
+import com.tinkerpop.blueprints.Direction;
+
+public abstract class Friend extends Person {
+    static final ClassInitializer<Friend> DEFAULT_INITIALIZER = new DefaultClassInitializer(Friend.class);
+    
+    
+    @Incidence(label="com.syncleus.ferma.Knows", direction=Direction.BOTH)
+    public abstract Knows addKnowsIncidence(Friend programmer);
+}

--- a/src/test/java/com/syncleus/ferma/Person.java
+++ b/src/test/java/com/syncleus/ferma/Person.java
@@ -41,6 +41,8 @@ public class Person extends AbstractVertexFrame {
 
         return out("knows").frame(Person.class).iterator();
     }
+    
+   
 
     public List<? extends Knows> getKnowsList() {
         return outE("knows").toList(Knows.class);


### PR DESCRIPTION
Hello,

As discussed in this thread, https://groups.google.com/a/syncleus.com/forum/#!topic/ferma-list/lrg-bzgyrl4 , I'm sending a pull request to add the functionality for @Incidence add* method. 

This is really helpful to make it easier to merge from Frames. 

One concern, this update forces full canonical name of Edge class. Though, it would be helpful to do it just by simple name but honestly, I couldn't find an easy way to get all annotated classes through the `FramedGraph`. If there is an easy way to get list of annotated edges, let me know, I will update the code and send a new pull request.

Thanks, 
Mohamed Taher Alrefaie