### PR TITLE
Add getFramedVertexExplicit method to FramedGraph and refactor usage of internal graph references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.2.0-SNAPSHOT
 
+* Added id parameter to ```fg.addFramedVertex``` and ```fg.addFramedEdge``` methods to prepare for orientdb custom vertex and edge types.
 * Added getFramedVertexExplicit method which can be used to load a framed vertex by id.
 * The internal references to the nested graph and the nested element within a element frame have been changed in order to enable custom getElement/getGraph methods which may be desired in some cases.
   * [Example usecase](https://github.com/Syncleus/Ferma/issues/10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Ferma Changelog
 
+## 2.2.0-SNAPSHOT
+
+* Added getFramedVertexExplicit method which can be used to load a framed vertex by id.
+* The internal references to the nested graph and the nested element within a element frame have been changed in order to enable custom getElement/getGraph methods which may be desired in some cases.
+  * [Example usecase](https://github.com/Syncleus/Ferma/issues/10)
+
 ## 2.1.0
 
 * Fixed a bug where an exception was thrown when using the @Adjacency annotation on outgoing adjacencies for add*, set*, and remove*.

--- a/src/main/java/com/syncleus/ferma/AbstractElementFrame.java
+++ b/src/main/java/com/syncleus/ferma/AbstractElementFrame.java
@@ -51,7 +51,7 @@ public abstract class AbstractElementFrame implements ElementFrame {
 
     /**
      * This method is only called when creating new elements that don't already exist in the graph. This method should
-     * be overridden to initalize any properties of an element on its creation. If an element is being framed that
+     * be overridden to initialize any properties of an element on its creation. If an element is being framed that
      * already exists in the graph this method will not be called.
      */
     protected void init() {
@@ -60,37 +60,42 @@ public abstract class AbstractElementFrame implements ElementFrame {
 
     @Override
     public <N> N getId() {
-        return (N) element.getId();
+        return (N) getElement().getId();
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return element.getPropertyKeys();
+        return getElement().getPropertyKeys();
     }
 
     @Override
     public Class<?> getTypeResolution() {
-        return getGraph().getTypeResolver().resolve(element);
+        return getGraph().getTypeResolver().resolve(getElement());
     }
 
     @Override
     public void setTypeResolution(final Class<?> type) {
-        getGraph().getTypeResolver().init(element, type);
+        getGraph().getTypeResolver().init(getElement(), type);
     }
 
     @Override
     public void removeTypeResolution() {
-        getGraph().getTypeResolver().deinit(element);
+        getGraph().getTypeResolver().deinit(getElement());
     }
 
     @Override
     public void remove() {
-        element.remove();
+        getElement().remove();
     }
 
     @Override
     public Element getElement() {
         return element;
+    }
+
+    @Override
+    public void setElement(Element element) {
+        this.element = element;
     }
 
     @Override
@@ -100,25 +105,26 @@ public abstract class AbstractElementFrame implements ElementFrame {
 
     @Override
     public <T> T getProperty(final String name) {
-        return element.getProperty(name);
+        return getElement().getProperty(name);
     }
 
     @Override
     public <T> T getProperty(final String name, final Class<T> type) {
-        if (type.isEnum())
-            return (T) Enum.valueOf((Class<Enum>) type, (String) element.getProperty(name));
-
-        return element.getProperty(name);
+        if (type.isEnum()) {
+            return (T) Enum.valueOf((Class<Enum>) type, (String) getElement().getProperty(name));
+        }
+        return getElement().getProperty(name);
     }
 
     @Override
     public void setProperty(final String name, final Object value) {
-        if (value == null)
-            element.removeProperty(name);
-        else if (value instanceof Enum)
-            element.setProperty(name, value.toString());
-        else
-            element.setProperty(name, value);
+        if (value == null) {
+            getElement().removeProperty(name);
+        } else if (value instanceof Enum) {
+            getElement().setProperty(name, value.toString());
+        } else {
+            getElement().setProperty(name, value);
+        }
     }
 
     @Override
@@ -143,7 +149,7 @@ public abstract class AbstractElementFrame implements ElementFrame {
 
     @Override
     public int hashCode() {
-        return element.hashCode();
+        return getElement().hashCode();
     }
 
     @Override
@@ -155,23 +161,21 @@ public abstract class AbstractElementFrame implements ElementFrame {
         if (getClass() != o.getClass())
             return false;
         final AbstractElementFrame other = (AbstractElementFrame) o;
-        if (element == null) {
-            if (other.element != null)
+        if (getElement() == null) {
+            if (other.getElement() != null)
                 return false;
         }
-        else if (!element.equals(other.element))
+        else if (!getElement().equals(other.getElement()))
             return false;
         return true;
     }
 
     protected <N> N getId(final Class<N> clazz) {
-
         return (N) getId();
     }
 
     @Override
     public String toString() {
-
         return getElement().toString();
     }
 

--- a/src/main/java/com/syncleus/ferma/AbstractElementFrame.java
+++ b/src/main/java/com/syncleus/ferma/AbstractElementFrame.java
@@ -27,8 +27,6 @@ package com.syncleus.ferma;
 import com.syncleus.ferma.traversals.VertexTraversal;
 import com.syncleus.ferma.traversals.EdgeTraversal;
 import java.util.Set;
-
-import com.syncleus.ferma.framefactories.annotation.CachesReflection;
 import com.tinkerpop.blueprints.Element;
 
 /**
@@ -72,17 +70,17 @@ public abstract class AbstractElementFrame implements ElementFrame {
 
     @Override
     public Class<?> getTypeResolution() {
-        return this.graph.getTypeResolver().resolve(element);
+        return getGraph().getTypeResolver().resolve(element);
     }
 
     @Override
     public void setTypeResolution(final Class<?> type) {
-        this.graph.getTypeResolver().init(element, type);
+        getGraph().getTypeResolver().init(element, type);
     }
 
     @Override
     public void removeTypeResolution() {
-        this.graph.getTypeResolver().deinit(element);
+        getGraph().getTypeResolver().deinit(element);
     }
 
     @Override
@@ -125,22 +123,22 @@ public abstract class AbstractElementFrame implements ElementFrame {
 
     @Override
     public VertexTraversal<?, ?, ?> v() {
-        return graph.v();
+        return getGraph().v();
     }
 
     @Override
     public EdgeTraversal<?, ?, ?> e() {
-        return graph.e();
+        return getGraph().e();
     }
 
     @Override
     public VertexTraversal<?, ?, ?> v(final Object... ids) {
-        return graph.v(ids);
+        return getGraph().v(ids);
     }
 
     @Override
     public EdgeTraversal<?, ?, ?> e(final Object... ids) {
-        return graph.e(ids);
+        return getGraph().e(ids);
     }
 
     @Override

--- a/src/main/java/com/syncleus/ferma/AbstractVertexFrame.java
+++ b/src/main/java/com/syncleus/ferma/AbstractVertexFrame.java
@@ -209,7 +209,7 @@ public abstract class AbstractVertexFrame extends AbstractElementFrame implement
 
     @Override
     public <K> K setLinkOut(final ClassInitializer<K> initializer, final String... labels) {
-        final K vertex = getGraph().addFramedVertex(initializer);
+        final K vertex = getGraph().addFramedVertex(null, initializer);
         setLinkOut((VertexFrame) vertex, labels);
         return vertex;
     }
@@ -233,7 +233,7 @@ public abstract class AbstractVertexFrame extends AbstractElementFrame implement
 
     @Override
     public <K> K setLinkIn(final ClassInitializer<K> initializer, final String... labels) {
-        final K vertex = getGraph().addFramedVertex(initializer);
+        final K vertex = getGraph().addFramedVertex(null, initializer);
         setLinkIn((VertexFrame) vertex, labels);
         return vertex;
     }
@@ -257,7 +257,7 @@ public abstract class AbstractVertexFrame extends AbstractElementFrame implement
 
     @Override
     public <K> K setLinkBoth(final ClassInitializer<K> initializer, final String... labels) {
-        final K vertex = getGraph().addFramedVertex(initializer);
+        final K vertex = getGraph().addFramedVertex(null, initializer);
         setLinkBoth((VertexFrame) vertex, labels);
         return vertex;
     }

--- a/src/main/java/com/syncleus/ferma/DelegatingFramedGraph.java
+++ b/src/main/java/com/syncleus/ferma/DelegatingFramedGraph.java
@@ -37,9 +37,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.syncleus.ferma.framefactories.annotation.AnnotationFrameFactory;
 import com.tinkerpop.blueprints.*;
-import com.tinkerpop.blueprints.util.wrappers.WrapperGraph;
 import com.tinkerpop.blueprints.util.wrappers.wrapped.WrappedGraph;
-import net.bytebuddy.dynamic.ClassFileLocator;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -293,14 +291,14 @@ public class DelegatingFramedGraph<G extends Graph> extends WrappedGraph<G> impl
     }
 
     @Override
-    public <T> T addFramedVertex(final ClassInitializer<T> initializer) {
-        final T framedVertex = frameNewElement(this.getBaseGraph().addVertex(null), initializer);
+    public <T> T addFramedVertex(Object id, final ClassInitializer<T> initializer) {
+        final T framedVertex = frameNewElement(this.getBaseGraph().addVertex(id), initializer);
         return framedVertex;
     }
     
     @Override
     public <T> T addFramedVertex(final Class<T> kind) {
-        return this.addFramedVertex(new DefaultClassInitializer<>(kind));
+        return this.addFramedVertex(null, new DefaultClassInitializer<>(kind));
     }
 
     @Override
@@ -316,8 +314,7 @@ public class DelegatingFramedGraph<G extends Graph> extends WrappedGraph<G> impl
 
     @Override
     public TVertex addFramedVertex() {
-
-        return addFramedVertex(TVertex.DEFAULT_INITIALIZER);
+        return addFramedVertex(null, TVertex.DEFAULT_INITIALIZER);
     }
 
     @Override
@@ -327,14 +324,14 @@ public class DelegatingFramedGraph<G extends Graph> extends WrappedGraph<G> impl
     }
 
     @Override
-    public <T> T addFramedEdge(final VertexFrame source, final VertexFrame destination, final String label, final ClassInitializer<T> initializer) {
-        final T framedEdge = frameNewElement(this.getBaseGraph().addEdge(null, source.getElement(), destination.getElement(), label), initializer);
+    public <T> T addFramedEdge(final Object id, final VertexFrame source, final VertexFrame destination, final String label, final ClassInitializer<T> initializer) {
+        final T framedEdge = frameNewElement(this.getBaseGraph().addEdge(id, source.getElement(), destination.getElement(), label), initializer);
         return framedEdge;
     }
     
     @Override
     public <T> T addFramedEdge(final VertexFrame source, final VertexFrame destination, final String label, final Class<T> kind) {
-        return this.addFramedEdge(source, destination, label, new DefaultClassInitializer<>(kind));
+        return this.addFramedEdge(null, source, destination, label, new DefaultClassInitializer<>(kind));
     }
 
     @Override
@@ -350,8 +347,7 @@ public class DelegatingFramedGraph<G extends Graph> extends WrappedGraph<G> impl
 
     @Override
     public TEdge addFramedEdge(final VertexFrame source, final VertexFrame destination, final String label) {
-
-        return addFramedEdge(source, destination, label, TEdge.DEFAULT_INITIALIZER);
+        return addFramedEdge(null, source, destination, label, TEdge.DEFAULT_INITIALIZER);
     }
 
     @Override

--- a/src/main/java/com/syncleus/ferma/DelegatingFramedGraph.java
+++ b/src/main/java/com/syncleus/ferma/DelegatingFramedGraph.java
@@ -371,6 +371,11 @@ public class DelegatingFramedGraph<G extends Graph> extends WrappedGraph<G> impl
     }
 
     @Override
+    public <F> F getFramedVertexExplicit(Class<F> classOfF, Object id) {
+        return frameElement(this.getBaseGraph().getVertex(id), classOfF);
+    }
+
+    @Override
     public <F> Iterable<? extends F> getFramedVertices(final Class<F> kind) {
         return new FramingVertexIterable<>(this, this.getVertices(), kind);
     }

--- a/src/main/java/com/syncleus/ferma/ElementFrame.java
+++ b/src/main/java/com/syncleus/ferma/ElementFrame.java
@@ -46,6 +46,12 @@ public interface ElementFrame {
     Element getElement();
 
     /**
+     * Set the underlying element.
+     * @param element
+     */
+	void setElement(Element element);
+
+    /**
      * @return The underlying graph.
      */
     FramedGraph getGraph();
@@ -137,4 +143,5 @@ public interface ElementFrame {
      * @return The query.
      */
     EdgeTraversal<?, ?, ?> e(final Object... ids);
+
 }

--- a/src/main/java/com/syncleus/ferma/FramedGraph.java
+++ b/src/main/java/com/syncleus/ferma/FramedGraph.java
@@ -40,11 +40,13 @@ public interface FramedGraph extends Graph {
      * Add a vertex to the graph
      *
      * @param <T> The type used to frame the element.
+     * @param id
+     *            the recommended object identifier
      * @param initializer
      *            the initializer for the frame which defines its type and may initialize properties
      * @return The framed vertex.
      */
-    <T> T addFramedVertex(ClassInitializer<T> initializer);
+    <T> T addFramedVertex(Object id, ClassInitializer<T> initializer);
     
     /**
      * Add a vertex to the graph
@@ -106,15 +108,16 @@ public interface FramedGraph extends Graph {
      * Add a edge to the graph
      *
      * @param <T> The type used to frame the element.
-     * @param source The source vertex
+     * @param id the recommended object identifier
+     * @param source the source vertex
      * @param destination the destination vertex
      * @param label the label.
      * @param initializer
      *            the initializer for the frame which defines its type and may initialize properties
      * @return The framed edge.
      */
-    <T> T addFramedEdge(final VertexFrame source, final VertexFrame destination, final String label, ClassInitializer<T> initializer);
-    
+    <T> T addFramedEdge(final Object id, final VertexFrame source, final VertexFrame destination, final String label, ClassInitializer<T> initializer);
+
     /**
      * Add a edge to the graph
      *

--- a/src/main/java/com/syncleus/ferma/FramedGraph.java
+++ b/src/main/java/com/syncleus/ferma/FramedGraph.java
@@ -200,6 +200,8 @@ public interface FramedGraph extends Graph {
      */
     EdgeTraversal<?, ?, ?> e();
 
+    <F> F getFramedVertexExplicit(Class<F> classOfF, Object id);
+
     <F> Iterable<? extends F> getFramedVertices(final Class<F> kind);
 
     <F> Iterable<? extends F> getFramedVertices(final String key, final Object value, final Class<F> kind);

--- a/src/main/java/com/syncleus/ferma/framefactories/annotation/AdjacencyMethodHandler.java
+++ b/src/main/java/com/syncleus/ferma/framefactories/annotation/AdjacencyMethodHandler.java
@@ -263,7 +263,7 @@ public class AdjacencyMethodHandler implements MethodHandler {
 
         @RuntimeType
         public static Object addVertex(@This final VertexFrame thiz, @Origin final Method method, @RuntimeType @Argument(value = 0) final ClassInitializer vertexType) {
-            final Object newNode = thiz.getGraph().addFramedVertex(vertexType);
+            final Object newNode = thiz.getGraph().addFramedVertex(null, vertexType);
             assert newNode instanceof VertexFrame;
             final VertexFrame newVertex = ((VertexFrame) newNode);
 
@@ -297,7 +297,7 @@ public class AdjacencyMethodHandler implements MethodHandler {
 
         @RuntimeType
         public static Object addVertex(@This final VertexFrame thiz, @Origin final Method method, @RuntimeType @Argument(0) final ClassInitializer vertexType, @RuntimeType @Argument(1) final ClassInitializer edgeType) {
-            final Object newNode = thiz.getGraph().addFramedVertex(vertexType);
+            final Object newNode = thiz.getGraph().addFramedVertex(null, vertexType);
             assert newNode instanceof VertexFrame;
             final VertexFrame newVertex = ((VertexFrame) newNode);
 
@@ -310,14 +310,14 @@ public class AdjacencyMethodHandler implements MethodHandler {
 
             switch (direction) {
                 case BOTH:
-                    thiz.getGraph().addFramedEdge(newVertex, thiz, label, edgeType);
-                    thiz.getGraph().addFramedEdge(thiz, newVertex, label, edgeType);
+                    thiz.getGraph().addFramedEdge(null, newVertex, thiz, label, edgeType);
+                    thiz.getGraph().addFramedEdge(null, thiz, newVertex, label, edgeType);
                     break;
                 case IN:
-                    thiz.getGraph().addFramedEdge(newVertex, thiz, label, edgeType);
+                    thiz.getGraph().addFramedEdge(null, newVertex, thiz, label, edgeType);
                     break;
                 case OUT:
-                    thiz.getGraph().addFramedEdge(thiz, newVertex, label, edgeType);
+                    thiz.getGraph().addFramedEdge(null, thiz, newVertex, label, edgeType);
                     break;
                 default:
                     throw new IllegalStateException(method.getName() + " is annotated with a direction other than BOTH, IN, or OUT.");
@@ -366,14 +366,14 @@ public class AdjacencyMethodHandler implements MethodHandler {
 
             switch (direction) {
                 case BOTH:
-                    thiz.getGraph().addFramedEdge(newVertex, thiz, label, edgeType);
-                    thiz.getGraph().addFramedEdge(thiz, newVertex, label, edgeType);
+                    thiz.getGraph().addFramedEdge(null, newVertex, thiz, label, edgeType);
+                    thiz.getGraph().addFramedEdge(null, thiz, newVertex, label, edgeType);
                     break;
                 case IN:
-                    thiz.getGraph().addFramedEdge(newVertex, thiz, label, edgeType);
+                    thiz.getGraph().addFramedEdge(null, newVertex, thiz, label, edgeType);
                     break;
                 case OUT:
-                    thiz.getGraph().addFramedEdge(thiz, newVertex, label, edgeType);
+                    thiz.getGraph().addFramedEdge(null, thiz, newVertex, label, edgeType);
                     break;
                 default:
                     throw new IllegalStateException(method.getName() + " is annotated with a direction other than BOTH, IN, or OUT.");

--- a/src/main/java/com/syncleus/ferma/framefactories/annotation/IncidenceMethodHandler.java
+++ b/src/main/java/com/syncleus/ferma/framefactories/annotation/IncidenceMethodHandler.java
@@ -165,7 +165,7 @@ public class IncidenceMethodHandler implements MethodHandler {
 
         @RuntimeType
         public static Object addVertex(@This final VertexFrame thiz, @Origin final Method method, @RuntimeType @Argument(value = 0) final ClassInitializer vertexType) {
-            final Object newNode = thiz.getGraph().addFramedVertex(vertexType);
+            final Object newNode = thiz.getGraph().addFramedVertex(null, vertexType);
             assert newNode instanceof VertexFrame;
             final VertexFrame newVertex = ((VertexFrame) newNode);
 
@@ -193,7 +193,7 @@ public class IncidenceMethodHandler implements MethodHandler {
 
         @RuntimeType
         public static Object addVertex(@This final VertexFrame thiz, @Origin final Method method, @RuntimeType @Argument(0) final ClassInitializer vertexType, @RuntimeType @Argument(1) final ClassInitializer edgeType) {
-            final Object newNode = thiz.getGraph().addFramedVertex(vertexType);
+            final Object newNode = thiz.getGraph().addFramedVertex(null, vertexType);
             assert newNode instanceof VertexFrame;
             final VertexFrame newVertex = ((VertexFrame) newNode);
 
@@ -208,9 +208,9 @@ public class IncidenceMethodHandler implements MethodHandler {
                 case BOTH:
                     throw new IllegalStateException(method.getName() + " is annotated with direction BOTH, this is not allowed for add methods annotated with @Incidence.");
                 case IN:
-                    return thiz.getGraph().addFramedEdge(newVertex, thiz, label, edgeType);
+                    return thiz.getGraph().addFramedEdge(null, newVertex, thiz, label, edgeType);
                 case OUT:
-                    return thiz.getGraph().addFramedEdge(thiz, newVertex, label, edgeType);
+                    return thiz.getGraph().addFramedEdge(null, thiz, newVertex, label, edgeType);
                 default:
                     throw new IllegalStateException(method.getName() + " is annotated with a direction other than BOTH, IN, or OUT.");
             }
@@ -252,9 +252,9 @@ public class IncidenceMethodHandler implements MethodHandler {
                 case BOTH:
                     throw new IllegalStateException(method.getName() + " is annotated with direction BOTH, this is not allowed for add methods annotated with @Incidence.");
                 case IN:
-                    return thiz.getGraph().addFramedEdge(newVertex, thiz, label, edgeType);
+                    return thiz.getGraph().addFramedEdge(null, newVertex, thiz, label, edgeType);
                 case OUT:
-                    return thiz.getGraph().addFramedEdge(thiz, newVertex, label, edgeType);
+                    return thiz.getGraph().addFramedEdge(null, thiz, newVertex, label, edgeType);
                 default:
                     throw new IllegalStateException(method.getName() + " is annotated with a direction other than BOTH, IN, or OUT.");
             }

--- a/src/main/java/com/syncleus/ferma/traversals/AbstractVertexTraversal.java
+++ b/src/main/java/com/syncleus/ferma/traversals/AbstractVertexTraversal.java
@@ -433,7 +433,7 @@ abstract class AbstractVertexTraversal<C, S, M> extends AbstractTraversal<Vertex
             return graph().frameElement((Element) getPipeline().next(), initializer.getInitializationType());
         }
         catch (final NoSuchElementException e) {
-            return graph().addFramedVertex(initializer);
+            return graph().addFramedVertex(null, initializer);
         }
     }
     
@@ -448,7 +448,7 @@ abstract class AbstractVertexTraversal<C, S, M> extends AbstractTraversal<Vertex
             return graph().frameElementExplicit((Element) getPipeline().next(), initializer.getInitializationType());
         }
         catch (final NoSuchElementException e) {
-            return graph().addFramedVertex(initializer);
+            return graph().addFramedVertex(null, initializer);
         }
     }
     

--- a/src/test/java/com/syncleus/ferma/AbstractElementFrameTest.java
+++ b/src/test/java/com/syncleus/ferma/AbstractElementFrameTest.java
@@ -35,8 +35,8 @@ public class AbstractElementFrameTest {
         MockitoAnnotations.initMocks(this);
         final Graph g = new TinkerGraph();
         final FramedGraph fg = new DelegatingFramedGraph(g);
-        p1 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
-        final Person p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        p1 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
+        final Person p2 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         p1.setName("Bryn");
         p2.setName("Julia");
         e1 = p1.addKnows(p2);

--- a/src/test/java/com/syncleus/ferma/FramedEdgeTest.java
+++ b/src/test/java/com/syncleus/ferma/FramedEdgeTest.java
@@ -39,8 +39,8 @@ public class FramedEdgeTest {
         MockitoAnnotations.initMocks(this);
         final Graph g = new TinkerGraph();
         fg = new DelegatingFramedGraph(g);
-        p1 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
-        p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        p1 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
+        p2 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         p1.setName("Bryn");
         p2.setName("Julia");
         e1 = p1.addKnows(p2);

--- a/src/test/java/com/syncleus/ferma/FramedGraphTest.java
+++ b/src/test/java/com/syncleus/ferma/FramedGraphTest.java
@@ -17,6 +17,7 @@
 package com.syncleus.ferma;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Collection;
 import java.util.List;
@@ -418,5 +419,17 @@ public class FramedGraphTest {
 
         final Collection<? extends Integer> knowsCollection = fg.v().has("name", "Julia").bothE().property("years", Integer.class).aggregate().cap();
         Assert.assertEquals(1, knowsCollection.size());
+    }
+
+    @Test
+    public void testGetFramedVertexExplicit() {
+        final Graph g = new TinkerGraph();
+        final FramedGraph fg = new DelegatingFramedGraph(g);
+        final TVertex p1 = fg.addFramedVertexExplicit();
+        p1.setProperty("name", "Bryn");
+
+        Person p = fg.getFramedVertexExplicit(Person.class, p1.getId());
+        assertNotNull(p);
+        assertEquals("Bryn", p.getName());
     }
 }

--- a/src/test/java/com/syncleus/ferma/FramedGraphTest.java
+++ b/src/test/java/com/syncleus/ferma/FramedGraphTest.java
@@ -49,10 +49,10 @@ public class FramedGraphTest {
         final Graph g = new TinkerGraph();
         final FramedGraph fg = new DelegatingFramedGraph(g);
 
-        final Person p1 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        final Person p1 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         p1.setName("Bryn");
 
-        final Person p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        final Person p2 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         p2.setName("Julia");
         final Knows knows = p1.addKnows(p2);
         knows.setYears(15);
@@ -138,14 +138,14 @@ public class FramedGraphTest {
         final Graph g = new TinkerGraph();
         final FramedGraph fg = new DelegatingFramedGraph(g, true, false);
 
-        Person rootPerson = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        Person rootPerson = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         for (int i = 0; i < 10; i++) {
-            Person person = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+            Person person = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
             rootPerson.addKnows(person);
         }
 
         for (int i = 0; i < 5; i++) {
-            Program program = fg.addFramedVertex(Program.DEFAULT_INITIALIZER);
+            Program program = fg.addFramedVertex(null, Program.DEFAULT_INITIALIZER);
             program.getElement().addEdge("UNTYPED_EDGE", rootPerson.getElement());
         }
 
@@ -168,10 +168,10 @@ public class FramedGraphTest {
         final Graph g = new TinkerGraph();
         final FramedGraph fg = new DelegatingFramedGraph(g, true, false);
 
-        final Person p1 = fg.addFramedVertex(Programmer.DEFAULT_INITIALIZER);
+        final Person p1 = fg.addFramedVertex(null, Programmer.DEFAULT_INITIALIZER);
         p1.setName("Bryn");
 
-        final Person p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        final Person p2 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         p2.setName("Julia");
 
         final Person bryn = fg.v().has("name", "Bryn").next(Person.class);
@@ -252,10 +252,10 @@ public class FramedGraphTest {
         final Graph g = new TinkerGraph();
         final FramedGraph fg = new DelegatingFramedGraph(g, true, false);
 
-        final Person p1 = fg.addFramedVertex(Programmer.DEFAULT_INITIALIZER);
+        final Person p1 = fg.addFramedVertex(null, Programmer.DEFAULT_INITIALIZER);
         p1.setName("Bryn");
 
-        final Person p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        final Person p2 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         p2.setName("Julia");
 
         final Person bryn = fg.v().has("name", "Bryn").nextExplicit(Person.class);
@@ -301,7 +301,7 @@ public class FramedGraphTest {
                 return (T) o;
             }
         }, new PolymorphicTypeResolver());
-        final Person person = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        final Person person = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         Assert.assertEquals(o, person);
     }
     

--- a/src/test/java/com/syncleus/ferma/FramedVertexTest.java
+++ b/src/test/java/com/syncleus/ferma/FramedVertexTest.java
@@ -40,8 +40,8 @@ public class FramedVertexTest {
         MockitoAnnotations.initMocks(this);
         final Graph g = new TinkerGraph();
         fg = new DelegatingFramedGraph(g);
-        p1 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
-        p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        p1 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
+        p2 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         p1.setName("Bryn");
         p2.setName("Julia");
         e1 = p1.addKnows(p2);

--- a/src/test/java/com/syncleus/ferma/Person.java
+++ b/src/test/java/com/syncleus/ferma/Person.java
@@ -36,11 +36,8 @@ public class Person extends AbstractVertexFrame {
     }
 
     public Iterator<Person> getKnowsExplicit() {
-
         return out("knows").frame(Person.class).iterator();
     }
-    
-   
 
     public List<? extends Knows> getKnowsList() {
         return outE("knows").toList(Knows.class);

--- a/src/test/java/com/syncleus/ferma/PolymorphicTypeResolverTest.java
+++ b/src/test/java/com/syncleus/ferma/PolymorphicTypeResolverTest.java
@@ -56,10 +56,10 @@ public class PolymorphicTypeResolverTest {
         final ReflectionCache cache = new ReflectionCache(TEST_TYPES);
         final FramedGraph fg = new DelegatingFramedGraph(g, new AnnotationFrameFactory(cache), new PolymorphicTypeResolver(cache, CUSTOM_TYPE_KEY));
 
-        final Person p1 = fg.addFramedVertex(Programmer.DEFAULT_INITIALIZER);
+        final Person p1 = fg.addFramedVertex(null, Programmer.DEFAULT_INITIALIZER);
         p1.setName("Bryn");
 
-        final Person p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER);
+        final Person p2 = fg.addFramedVertex(null, Person.DEFAULT_INITIALIZER);
         p2.setName("Julia");
 
         final Person bryn = fg.v().has("name", "Bryn").next(Person.class);

--- a/src/test/java/com/syncleus/ferma/annotations/AdjacencyMethodHandlerTest.java
+++ b/src/test/java/com/syncleus/ferma/annotations/AdjacencyMethodHandlerTest.java
@@ -240,7 +240,7 @@ public class AdjacencyMethodHandlerTest {
         final VertexFrame fatherVertex = father;
         Assert.assertEquals(fatherVertex.getProperty("name"), "jupiter");
 
-        final God child = framedGraph.addFramedVertex(God.DEFAULT_INITIALIZER);
+        final God child = framedGraph.addFramedVertex(null, God.DEFAULT_INITIALIZER);
         father.addSon(child);
 
         Assert.assertTrue(child != null);
@@ -282,7 +282,7 @@ public class AdjacencyMethodHandlerTest {
         final VertexFrame fatherVertex = father;
         Assert.assertEquals(fatherVertex.getProperty("name"), "jupiter");
 
-        final God child = framedGraph.addFramedVertex(God.DEFAULT_INITIALIZER);
+        final God child = framedGraph.addFramedVertex(null, God.DEFAULT_INITIALIZER);
         father.addSon(child, FatherEdge.DEFAULT_INITIALIZER);
 
         Assert.assertTrue(child != null);
@@ -336,7 +336,7 @@ public class AdjacencyMethodHandlerTest {
         Assert.assertEquals(childVertex.getElement().getProperty("name"), "hercules");
         Assert.assertTrue(child instanceof GodExtended);
 
-        father.setSons(Arrays.asList(framedGraph.addFramedVertex(God.DEFAULT_INITIALIZER)));
+        father.setSons(Arrays.asList(framedGraph.addFramedVertex(null, God.DEFAULT_INITIALIZER)));
 
         child = father.getSon(God.class);
         Assert.assertNotNull(child);


### PR DESCRIPTION
1. Minor update that allows easy retrieval of known vertices
2. By calling getGraph() instead of graph. it is possible to overwrite getGraph() and change the behavior.
3. By calling getElement() instead of element. it is possible to overwrite getElement() and change the behavior.

The changes are needed in order to provide custom abstract classes which are needed for OrientDB due to db specific transaction and multithreading cases.