### PR TITLE
Allow the value to a setter to be null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 .project
 .settings
 site
+.idea/
+ferma.iml
+

--- a/src/main/java/com/syncleus/ferma/framefactories/annotation/AdjacencyMethodHandler.java
+++ b/src/main/java/com/syncleus/ferma/framefactories/annotation/AdjacencyMethodHandler.java
@@ -645,16 +645,20 @@ public class AdjacencyMethodHandler extends AbstractMethodHandler {
             switch (direction) {
                 case BOTH:
                     thiz.unlinkBoth(null, label);
-                    thiz.getGraph().addFramedEdge(vertexFrame, thiz, label);
-                    thiz.getGraph().addFramedEdge(thiz, vertexFrame, label);
+                    if (vertexFrame != null) {
+                        thiz.getGraph().addFramedEdge(vertexFrame, thiz, label);
+                        thiz.getGraph().addFramedEdge(thiz, vertexFrame, label);
+                    }
                     break;
                 case IN:
                     thiz.unlinkIn(null, label);
-                    thiz.getGraph().addFramedEdge(vertexFrame, thiz, label);
+                    if (vertexFrame != null)
+                        thiz.getGraph().addFramedEdge(vertexFrame, thiz, label);
                     break;
                 case OUT:
                     thiz.unlinkOut(null, label);
-                    thiz.getGraph().addFramedEdge(thiz, vertexFrame, label);
+                    if (vertexFrame != null)
+                        thiz.getGraph().addFramedEdge(thiz, vertexFrame, label);
                     break;
                 default:
                     throw new IllegalStateException(method.getName() + " is annotated with a direction other than BOTH, IN, or OUT.");

--- a/src/main/java/com/syncleus/ferma/framefactories/annotation/AdjacencyMethodHandler.java
+++ b/src/main/java/com/syncleus/ferma/framefactories/annotation/AdjacencyMethodHandler.java
@@ -362,7 +362,7 @@ public class AdjacencyMethodHandler extends AbstractMethodHandler {
                     default:
                         throw new IllegalStateException("Direction not recognized.");
                 }
-            }).next(VertexFrame.class);
+            }).nextOrDefault(VertexFrame.class, null);
         }
     }
 

--- a/src/test/java/com/syncleus/ferma/annotations/AdjacencyMethodHandlerTest.java
+++ b/src/test/java/com/syncleus/ferma/annotations/AdjacencyMethodHandlerTest.java
@@ -324,6 +324,26 @@ public class AdjacencyMethodHandlerTest {
     }
 
     @Test
+    public void testSetSonNull() {
+
+        GodGraphLoader.load(godGraph);
+
+        final FramedGraph framedGraph = new DelegatingFramedGraph(godGraph, TEST_TYPES);
+
+        final List<? extends God> gods = framedGraph.traverse(
+            input -> input.V().has("name", "jupiter")).toList(God.class);
+
+        final God father = gods.iterator().next();
+        Assert.assertTrue(father != null);
+        final VertexFrame fatherVertex = father;
+        Assert.assertEquals(fatherVertex.getProperty("name"), "jupiter");
+
+        father.setSon(null);
+        final God sonNull = father.getSon();
+        Assert.assertNull(sonNull);
+    }
+
+    @Test
     public void testAddSonDefault() {
 
         GodGraphLoader.load(godGraph);


### PR DESCRIPTION
This simply unlinks the vertex in the case where the passed in vertex is null. This is similar to the frames behavior.