### PR TITLE
Allow the user to specify a non-default classloader for the annotation frame factory

### DIFF
--- a/src/main/java/com/syncleus/ferma/framefactories/annotation/AbstractAnnotationFrameFactory.java
+++ b/src/main/java/com/syncleus/ferma/framefactories/annotation/AbstractAnnotationFrameFactory.java
@@ -38,11 +38,17 @@ public class AbstractAnnotationFrameFactory implements FrameFactory {
     protected final Map<Class<? extends Annotation>, MethodHandler> methodHandlers = new HashMap<>();
     private final ReflectionCache reflectionCache;
     private final Map<Class, Class> constructedClassCache = new HashMap<>();
+    private final ClassLoader defaultClassLoader;
 
-    protected AbstractAnnotationFrameFactory(final ReflectionCache reflectionCache, Set<MethodHandler> handlers) {
+    protected AbstractAnnotationFrameFactory(final ClassLoader defaultClassLoader, final ReflectionCache reflectionCache, Set<MethodHandler> handlers) {
+        this.defaultClassLoader = defaultClassLoader;
         this.reflectionCache = reflectionCache;
         for(MethodHandler handler : handlers)
             this.methodHandlers.put(handler.getAnnotationType(), handler);
+    }
+
+    protected AbstractAnnotationFrameFactory(final ReflectionCache reflectionCache, Set<MethodHandler> handlers) {
+        this(AnnotationFrameFactory.class.getClassLoader(), reflectionCache, handlers);
     }
 
     private static boolean isAbstract(final Class<?> clazz) {
@@ -108,7 +114,7 @@ public class AbstractAnnotationFrameFactory implements FrameFactory {
                     }
                 }
 
-        constructedClass = classBuilder.make().load(AnnotationFrameFactory.class.getClassLoader(), ClassLoadingStrategy.Default.WRAPPER).getLoaded();
+        constructedClass = classBuilder.make().load(defaultClassLoader, ClassLoadingStrategy.Default.WRAPPER).getLoaded();
         this.constructedClassCache.put(clazz, constructedClass);
         return constructedClass;
     }

--- a/src/main/java/com/syncleus/ferma/framefactories/annotation/AnnotationFrameFactory.java
+++ b/src/main/java/com/syncleus/ferma/framefactories/annotation/AnnotationFrameFactory.java
@@ -15,24 +15,15 @@
  */
 package com.syncleus.ferma.framefactories.annotation;
 
-import com.syncleus.ferma.framefactories.FrameFactory;
 import com.syncleus.ferma.*;
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.description.modifier.FieldManifestation;
-import net.bytebuddy.description.modifier.Visibility;
-import net.bytebuddy.dynamic.DynamicType;
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
-import net.bytebuddy.implementation.FieldAccessor;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.*;
 
 public class AnnotationFrameFactory extends AbstractAnnotationFrameFactory {
+
+    public AnnotationFrameFactory(final ClassLoader defaultClassLoader, final ReflectionCache reflectionCache) {
+        super(defaultClassLoader, reflectionCache, collectHandlers(null));
+    }
 
     public AnnotationFrameFactory(final ReflectionCache reflectionCache) {
         super(reflectionCache, collectHandlers(null));


### PR DESCRIPTION
This is really still not sufficient for our use case, as we also rely on the typemanager being able to return multiple interface classes.

I wonder if that is something that we could integrate into upstream later on? Perhaps we can talk about it more?