### PR TITLE
Added keyValues for addFramedVertex with class type

### DIFF
--- a/src/main/java/com/syncleus/ferma/DelegatingFramedGraph.java
+++ b/src/main/java/com/syncleus/ferma/DelegatingFramedGraph.java
@@ -325,6 +325,11 @@ public class DelegatingFramedGraph<G extends Graph> implements WrappedFramedGrap
     }
     
     @Override
+    public <T> T addFramedVertex(final Class<T> kind, final Object... keyValues) {
+        return this.addFramedVertex(new DefaultClassInitializer<>(kind), keyValues);
+    }
+    
+    @Override
     public <T> T addFramedVertex(final Class<T> kind) {
         return this.addFramedVertex(new DefaultClassInitializer<>(kind));
     }

--- a/src/main/java/com/syncleus/ferma/FramedGraph.java
+++ b/src/main/java/com/syncleus/ferma/FramedGraph.java
@@ -51,6 +51,18 @@ public interface FramedGraph extends AutoCloseable {
      * @return The framed vertex.
      */
     <T> T addFramedVertex(ClassInitializer<T> initializer, Object... keyValues);
+
+    /**
+     * Add a vertex to the graph
+     *
+     * @param <T> The type used to frame the element.
+     * @param kind
+     *            The kind of the frame.
+     * @param keyValues
+     *            the recommended object identifier
+     * @return The framed vertex.
+     */
+    <T> T addFramedVertex(Class<T> kind, Object... keyValues);
     
     /**
      * Add a vertex to the graph

--- a/src/test/java/com/syncleus/ferma/FramedGraphTest.java
+++ b/src/test/java/com/syncleus/ferma/FramedGraphTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 import com.syncleus.ferma.typeresolvers.PolymorphicTypeResolver;
+import org.apache.tinkerpop.gremlin.structure.T;
 
 
 public class FramedGraphTest {
@@ -210,6 +211,52 @@ public class FramedGraphTest {
         Assert.assertEquals(Programmer.class, bryn.getClass());
         Assert.assertEquals(Person.class, julia.getClass());
 
+        Assert.assertNotNull(bryn.getElement().property(PolymorphicTypeResolver.TYPE_RESOLUTION_KEY).value());
+        Assert.assertNotNull(julia.getElement().property(PolymorphicTypeResolver.TYPE_RESOLUTION_KEY).value());
+    }
+
+    @Test
+    public void testKeyValues() {
+        final Graph g = TinkerGraph.open();
+        final FramedGraph fg = new DelegatingFramedGraph(g, true, false);
+
+        final Person p1 = fg.addFramedVertex(Programmer.DEFAULT_INITIALIZER, "key", "value");
+        p1.setName("Bryn");
+
+        final Person p2 = fg.addFramedVertex(Person.DEFAULT_INITIALIZER, T.label, "label");
+        p2.setName("Julia");
+
+        final Person bryn = fg.traverse(
+            input -> input.V().has("key", "value")).next(Person.class);
+        final Person julia = fg.traverse(
+            input -> input.V().hasLabel("label")).next(Person.class);
+
+        Assert.assertEquals(Programmer.class, bryn.getClass());
+        Assert.assertEquals(Person.class, julia.getClass());
+
+        Assert.assertNotNull(bryn.getElement().property(PolymorphicTypeResolver.TYPE_RESOLUTION_KEY).value());
+        Assert.assertNotNull(julia.getElement().property(PolymorphicTypeResolver.TYPE_RESOLUTION_KEY).value());
+    }
+
+    @Test
+    public void testKeyValuesByClass() {
+        final Graph g = TinkerGraph.open();
+        final FramedGraph fg = new DelegatingFramedGraph(g, true, false);
+
+        final Person p1 = fg.addFramedVertex(Programmer.class, "key", "value");
+        p1.setName("Bryn");
+
+        final Person p2 = fg.addFramedVertex(Person.class, T.label, "label");
+        p2.setName("Julia");
+
+        final Person bryn = fg.traverse(
+            input -> input.V().has("key", "value")).next(Person.class);
+        final Person julia = fg.traverse(
+            input -> input.V().hasLabel("label")).next(Person.class);
+
+        Assert.assertEquals(Programmer.class, bryn.getClass());
+        Assert.assertEquals(Person.class, julia.getClass());
+        
         Assert.assertNotNull(bryn.getElement().property(PolymorphicTypeResolver.TYPE_RESOLUTION_KEY).value());
         Assert.assertNotNull(julia.getElement().property(PolymorphicTypeResolver.TYPE_RESOLUTION_KEY).value());
     }


### PR DESCRIPTION
###--------------------------------------------------------###
feat(internal): Added keyValues for addFramedVertex with class type

Added the function `<T> T addFramedVertex(final Class<T> kind, final Object... keyValues)`
 as a way to add key values to vertex elements. This includes tests for this new function.
###--------------------------------------------------------###