### PR TITLE
Move TravisCI to OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   - CODACY_PROJECT_TOKEN=3b6d38f010804d1f8dd348c674db6ead
 before_install:


### PR DESCRIPTION
Fixes TravisCI builds. 
The solution retrieved from this comment: https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/3
Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>