### PR TITLE
Upgrade: Remove direct and indirect Guava dependency, update reflections (fixes #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Updated the following dependencies
   * org.apache.tinkerpop:gremlin-core 3.4.4 -> 3.4.6
   * org.apache.tinkerpop:tinkergraph-gremlin 3.4.4 -> 3.4.6
-
+  * org.reflections:reflections 0.9.12 -> net.oneandone.reflections8:reflections8 0.11.7
+* Removed Guava dependency, moved to Java 8 Stream API
 
 ## 3.3.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,11 +164,6 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.2-jre</version>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>2.0.2-beta</version>
@@ -180,9 +175,9 @@
             <version>1.10.6</version>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.9.12</version>
+            <groupId>net.oneandone.reflections8</groupId>
+            <artifactId>reflections8</artifactId>
+            <version>0.11.7</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/syncleus/ferma/DefaultTraversable.java
+++ b/src/main/java/com/syncleus/ferma/DefaultTraversable.java
@@ -15,15 +15,12 @@
  */
 package com.syncleus.ferma;
 
-import java.util.function.Function;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Element;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class DefaultTraversable<PE, E> implements Traversable<PE, E>{
     final private GraphTraversal<PE, E> baseTraversal;
@@ -125,22 +122,12 @@ public class DefaultTraversable<PE, E> implements Traversable<PE, E>{
 
     @Override
     public <N> List<? extends N> next(final int amount, final Class<N> kind) {
-        return Lists.transform((List<Element>) this.baseTraversal.next(amount), new com.google.common.base.Function<Element, N>() {
-            @Override
-            public N apply(final Element input) {
-                return parentGraph.frameElement(input, kind);
-            }
-        });
+        return ((List<Element>) this.baseTraversal.next(amount)).stream().map(input -> parentGraph.frameElement(input, kind)).collect(Collectors.toList());
     }
 
     @Override
     public <N> List<? extends N> nextExplicit(final int amount, final Class<N> kind) {
-        return Lists.transform((List<Element>) this.baseTraversal.next(amount), new com.google.common.base.Function<Element, N>() {
-            @Override
-            public N apply(final Element input) {
-                return parentGraph.frameElementExplicit(input, kind);
-            }
-        });
+        return ((List<Element>) this.baseTraversal.next(amount)).stream().map(input -> parentGraph.frameElementExplicit(input, kind)).collect(Collectors.toList());
     }
 
     @Override
@@ -175,31 +162,21 @@ public class DefaultTraversable<PE, E> implements Traversable<PE, E>{
 
     @Override
     public <N> List<? extends N> toList(final Class<N> kind) {
-        return Lists.transform((List<Element>) this.baseTraversal.toList(), new com.google.common.base.Function<Element, N>() {
-            @Override
-            public N apply(final Element input) {
-                return parentGraph.frameElement(input, kind);
-            }
-        });
+        return ((List<Element>) this.baseTraversal.toList()).stream().map(input -> parentGraph.frameElement(input, kind)).collect(Collectors.toList());
     }
 
     @Override
     public <N> List<? extends N> toListExplicit(final Class<N> kind) {
-        return Lists.transform((List<Element>) this.baseTraversal.toList(), new com.google.common.base.Function<Element, N>() {
-            @Override
-            public N apply(final Element input) {
-                return parentGraph.frameElementExplicit(input, kind);
-            }
-        });
+        return ((List<Element>) this.baseTraversal.toList()).stream().map(input -> parentGraph.frameElementExplicit(input, kind)).collect(Collectors.toList());
     }
 
     @Override
     public <N> Set<? extends N> toSet(final Class<N> kind) {
-        return Sets.newHashSet(toList(kind));
+        return new HashSet<>(toList(kind));
     }
 
     @Override
     public <N> Set<? extends N> toSetExplicit(final Class<N> kind) {
-        return Sets.newHashSet(toListExplicit(kind));
+        return new HashSet<>(toListExplicit(kind));
     }
 }

--- a/src/main/java/com/syncleus/ferma/DelegatingFramedGraph.java
+++ b/src/main/java/com/syncleus/ferma/DelegatingFramedGraph.java
@@ -23,13 +23,13 @@
  */
 package com.syncleus.ferma;
 
+import java.util.Spliterators;
 import java.util.function.Function;
 import com.syncleus.ferma.framefactories.FrameFactory;
 import com.syncleus.ferma.framefactories.DefaultFrameFactory;
 import com.syncleus.ferma.typeresolvers.UntypedTypeResolver;
 import com.syncleus.ferma.typeresolvers.TypeResolver;
 import com.syncleus.ferma.typeresolvers.PolymorphicTypeResolver;
-import com.google.common.collect.Iterators;
 import com.syncleus.ferma.framefactories.annotation.AnnotationFrameFactory;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -39,6 +39,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.stream.StreamSupport;
 
 public class DelegatingFramedGraph<G extends Graph> implements WrappedFramedGraph<G>{
 
@@ -264,14 +265,7 @@ public class DelegatingFramedGraph<G extends Graph> implements WrappedFramedGrap
 
     @Override
     public <T> Iterator<? extends T> frame(final Iterator<? extends Element> pipeline, final Class<T> kind) {
-        return Iterators.transform(pipeline, new com.google.common.base.Function<Element, T>() {
-
-            @Override
-            public T apply(final Element input) {
-                return frameElement(input, kind);
-            }
-
-        });
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(pipeline, 0), false).map(input -> frameElement(input, kind)).iterator();
     }
 
     @Override
@@ -302,25 +296,16 @@ public class DelegatingFramedGraph<G extends Graph> implements WrappedFramedGrap
 
     @Override
     public <T> Iterator<? extends T> frameExplicit(final Iterator<? extends Element> pipeline, final Class<T> kind) {
-        return Iterators.transform(pipeline, new com.google.common.base.Function<Element, T>() {
-
-            @Override
-            public T apply(final Element input) {
-                return frameElementExplicit(input, kind);
-            }
-
-        });
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(pipeline, 0), false).map(input -> frameElementExplicit(input, kind)).iterator();
     }
 
     @Override
     public <T> T addFramedVertex(final ClassInitializer<T> initializer, final Object... keyValues) {
         if( keyValues != null ) {
-            final T framedVertex = frameNewElement(this.getBaseGraph().addVertex(keyValues), initializer);
-            return framedVertex;
+            return frameNewElement(this.getBaseGraph().addVertex(keyValues), initializer);
         }
         else {
-            final T framedVertex = frameNewElement(this.getBaseGraph().addVertex(), initializer);
-            return framedVertex;
+            return frameNewElement(this.getBaseGraph().addVertex(), initializer);
         }
     }
     
@@ -336,8 +321,7 @@ public class DelegatingFramedGraph<G extends Graph> implements WrappedFramedGrap
 
     @Override
     public <T> T addFramedVertexExplicit(final ClassInitializer<T> initializer) {
-        final T framedVertex = frameNewElementExplicit(this.getBaseGraph().addVertex(), initializer);
-        return framedVertex;
+        return frameNewElementExplicit(this.getBaseGraph().addVertex(), initializer);
     }
     
     @Override
@@ -359,8 +343,7 @@ public class DelegatingFramedGraph<G extends Graph> implements WrappedFramedGrap
     @Override
     public <T> T addFramedEdge(final VertexFrame source, final VertexFrame destination, final String label, final ClassInitializer<T> initializer, final Object... keyValues) {
         final Edge baseEdge = source.getElement().addEdge(label, destination.getElement(), keyValues);
-        final T framedEdge = frameNewElement(baseEdge, initializer);
-        return framedEdge;
+        return frameNewElement(baseEdge, initializer);
     }
     
     @Override
@@ -370,8 +353,7 @@ public class DelegatingFramedGraph<G extends Graph> implements WrappedFramedGrap
 
     @Override
     public <T> T addFramedEdgeExplicit(final VertexFrame source, final VertexFrame destination, final String label, final ClassInitializer<T> initializer) {
-        final T framedEdge = frameNewElementExplicit(source.getElement().addEdge(label, destination.getElement()), initializer);
-        return framedEdge;
+        return frameNewElementExplicit(source.getElement().addEdge(label, destination.getElement()), initializer);
     }
     
     @Override

--- a/src/main/java/com/syncleus/ferma/ReflectionCache.java
+++ b/src/main/java/com/syncleus/ferma/ReflectionCache.java
@@ -16,11 +16,11 @@
 package com.syncleus.ferma;
 
 import com.syncleus.ferma.annotations.GraphElement;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
+import org.reflections8.Reflections;
+import org.reflections8.scanners.SubTypesScanner;
+import org.reflections8.scanners.TypeAnnotationsScanner;
+import org.reflections8.util.ClasspathHelper;
+import org.reflections8.util.ConfigurationBuilder;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;

--- a/src/main/java/com/syncleus/ferma/framefactories/annotation/InVertexMethodHandler.java
+++ b/src/main/java/com/syncleus/ferma/framefactories/annotation/InVertexMethodHandler.java
@@ -15,7 +15,6 @@
  */
 package com.syncleus.ferma.framefactories.annotation;
 
-import java.util.function.Function;
 import com.syncleus.ferma.EdgeFrame;
 import com.syncleus.ferma.annotations.InVertex;
 import net.bytebuddy.dynamic.DynamicType;
@@ -23,16 +22,11 @@ import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.Origin;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.This;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.Iterator;
-
 import net.bytebuddy.matcher.ElementMatchers;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
 
-import javax.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 
 /**
  * A method handler that implemented the InVertex Annotation.

--- a/src/main/java/com/syncleus/ferma/framefactories/annotation/OutVertexMethodHandler.java
+++ b/src/main/java/com/syncleus/ferma/framefactories/annotation/OutVertexMethodHandler.java
@@ -15,7 +15,6 @@
  */
 package com.syncleus.ferma.framefactories.annotation;
 
-import java.util.function.Function;
 import com.syncleus.ferma.EdgeFrame;
 import com.syncleus.ferma.annotations.OutVertex;
 import net.bytebuddy.dynamic.DynamicType;
@@ -23,16 +22,11 @@ import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.Origin;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.This;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.Iterator;
-
 import net.bytebuddy.matcher.ElementMatchers;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
 
-import javax.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 
 /**
  * A method handler that implemented the OutVertex Annotation.

--- a/src/test/java/com/syncleus/ferma/AbstractElementFrameTest.java
+++ b/src/test/java/com/syncleus/ferma/AbstractElementFrameTest.java
@@ -15,23 +15,22 @@
  */
 package com.syncleus.ferma;
 
+import com.google.gson.JsonObject;
+import com.syncleus.ferma.graphtypes.javaclass.JavaAccessModifier;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
-import com.google.common.collect.Sets;
-import com.google.gson.JsonObject;
-import com.syncleus.ferma.graphtypes.javaclass.JavaAccessModifier;
-import java.io.IOException;
-import java.util.Iterator;
 
-import org.apache.tinkerpop.gremlin.structure.T;
-import org.junit.After;
+import java.io.IOException;
+import java.util.HashSet;
 
 public class AbstractElementFrameTest {
 
@@ -59,12 +58,12 @@ public class AbstractElementFrameTest {
 
     @Test
     public void testGetId() {
-        Assert.assertEquals((Long) 0L, (Long) p1.getId());
+        Assert.assertEquals((Long) 0L, p1.getId());
     }
 
     @Test
     public void testGetPropertyKeys() {
-        Assert.assertEquals(Sets.newHashSet("name"), p1.getPropertyKeys());
+        Assert.assertEquals(new HashSet<String>(){{add("name");}}, p1.getPropertyKeys());
     }
 
     @Test

--- a/src/test/java/com/syncleus/ferma/FramedGraphTest.java
+++ b/src/test/java/com/syncleus/ferma/FramedGraphTest.java
@@ -15,20 +15,21 @@
  */
 package com.syncleus.ferma;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Consumer;
-import com.google.common.collect.Lists;
 import com.syncleus.ferma.framefactories.FrameFactory;
+import com.syncleus.ferma.typeresolvers.PolymorphicTypeResolver;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
-import com.syncleus.ferma.typeresolvers.PolymorphicTypeResolver;
-import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
 
 
 public class FramedGraphTest {
@@ -158,7 +159,9 @@ public class FramedGraphTest {
         final Iterator<? extends Person> persons = fg.traverse(
             input -> fg.getTypeResolver().hasType(input.V(), Person.class)).frameExplicit(Person.class);
 
-        final List<Person> personList = Lists.newArrayList(persons);
+        final List<Person> personList = new ArrayList<>();
+        persons.forEachRemaining(personList::add);
+
         Assert.assertEquals(11, personList.size());
         // Verify that all found persons have indeed been filtered
         persons.forEachRemaining(new Consumer<Person>() {

--- a/src/test/java/com/syncleus/ferma/FramedVertexTest.java
+++ b/src/test/java/com/syncleus/ferma/FramedVertexTest.java
@@ -15,23 +15,20 @@
  */
 package com.syncleus.ferma;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import java.util.function.Function;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
-import com.google.common.collect.Lists;
-import java.io.IOException;
 
-import javax.annotation.Nullable;
-import org.junit.After;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 public class FramedVertexTest {
     private static final Function<GraphTraversal<Vertex, Vertex>, GraphTraversal<?, ?>> OUT_TRAVERSAL = input -> input.out();

--- a/src/test/java/com/syncleus/ferma/Person.java
+++ b/src/test/java/com/syncleus/ferma/Person.java
@@ -15,8 +15,9 @@
  */
 package com.syncleus.ferma;
 
-import com.google.common.collect.Lists;
 import com.syncleus.ferma.annotations.GraphElement;
+
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -49,11 +50,15 @@ public class Person extends AbstractVertexFrame {
     }
 
     public List<? extends Person> getKnowsCollectionVertices() {
-        return Lists.<Person>newArrayList(getKnows());
+        List<Person> list = new ArrayList<>();
+        getKnows().forEachRemaining(list::add);
+        return list;
     }
 
     public List<? extends Person> getKnowsCollectionVerticesExplicit() {
-        return Lists.<Person>newArrayList(getKnowsExplicit());
+        List<Person> list = new ArrayList<>();
+        getKnowsExplicit().forEachRemaining(list::add);
+        return list;
     }
 
     public Person getFirst() {

--- a/src/test/java/com/syncleus/ferma/ReflectionCacheTest.java
+++ b/src/test/java/com/syncleus/ferma/ReflectionCacheTest.java
@@ -15,14 +15,14 @@
  */
 package com.syncleus.ferma;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.*;
 
 /**
  *
@@ -64,8 +64,19 @@ public class ReflectionCacheTest {
     public void testBadConstructorCall() {
         createCache(null);
     }
-    
+
+    @Test
+    public void testTypesAnnotatedWithUnusedAnnotation() {
+        new ReflectionCache(Collections.emptySet()).getTypesAnnotatedWith(UnusedTestAnnotation.class);
+    }
+
     private ReflectionCache createCache(Collection<? extends Class<?>> annotatedTypes) {
         return new ReflectionCache(annotatedTypes);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface UnusedTestAnnotation {
+
     }
 }

--- a/src/test/java/com/syncleus/ferma/annotations/IncidenceMethodHandlerTest.java
+++ b/src/test/java/com/syncleus/ferma/annotations/IncidenceMethodHandlerTest.java
@@ -15,19 +15,14 @@
  */
 package com.syncleus.ferma.annotations;
 
-import java.util.function.Function;
 import com.syncleus.ferma.DelegatingFramedGraph;
 import com.syncleus.ferma.EdgeFrame;
 import com.syncleus.ferma.FramedGraph;
 import com.syncleus.ferma.VertexFrame;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.util.*;
 
 public class IncidenceMethodHandlerTest {


### PR DESCRIPTION
Removes direct `guava` usage by moving to java 8 Stream API.
Remove indirect `guava` usage by moving `reflections` to `reflections8`
Fixes #60 by moving to `reflections8`

GitLab PR: https://git.qoto.org/Ferma/Ferma/-/merge_requests/3